### PR TITLE
Quick and dirty fix for changes to how ComfyUI handles conditionings

### DIFF
--- a/adv_encode.py
+++ b/adv_encode.py
@@ -238,7 +238,7 @@ def prepareXL(embs_l, embs_g, pooled, clip_balance):
 
 def advanced_encode(clip, text, token_normalization, weight_interpretation, w_max=1.0, clip_balance=.5, apply_to_pooled=True):
     tokenized = clip.tokenize(text, return_word_ids=True)
-    if isinstance(tokenized, dict):
+    if isinstance(clip.cond_stage_model, (SDXLClipModel, SDXLRefinerClipModel, SDXLClipG)):
         embs_l = None
         embs_g = None
         pooled = None
@@ -259,10 +259,10 @@ def advanced_encode(clip, text, token_normalization, weight_interpretation, w_ma
                                                          apply_to_pooled=apply_to_pooled)
         return prepareXL(embs_l, embs_g, pooled, clip_balance)
     else:
-        return advanced_encode_from_tokens(tokenized, 
+        return advanced_encode_from_tokens(tokenized['l'],
                                            token_normalization, 
                                            weight_interpretation, 
-                                           lambda x: (clip.encode_from_tokens(x), None),
+                                           lambda x: (clip.encode_from_tokens({'l': x}), None),
                                            w_max=w_max)
 def advanced_encode_XL(clip, text1, text2, token_normalization, weight_interpretation, w_max=1.0, clip_balance=.5, apply_to_pooled=True):
     tokenized1 = clip.tokenize(text1, return_word_ids=True)


### PR DESCRIPTION
Necessitated by https://github.com/comfyanonymous/ComfyUI/commit/e60ca6929a999f53a4eeb62cc80f70b1cd7a0acf

SD1 & 2 conditionings are dicts too now, so I changed how SDXL is detected and how the encode function is called. Tested in both SD1.5 and SDXL workflows and seems to work.